### PR TITLE
Serialize builds to prevent stale output race

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options = 
         await compilerPromise
       }
 
+      await compiler.build()
       const componentTag = parseTagConfig(code)
       const compilerFilePath = path.resolve(distCustomElementsOptions.dir, `${componentTag}.js`)
       const compilerFileExists = await compiler.sys.access(compilerFilePath)


### PR DESCRIPTION
## Description:
The unplugin-stencil plugin does not update the dist folder after launching the build and modifying a component. 


## Changes Made
Fix race condition where transform() could return stale output if a new build started during an ongoing one. Builds are now serialized and awaited using a version-safe loop, with a debounce added to coalesce rapid file changes.