### PR TITLE
Prevent Error When Stencil Build Output Is Missing During Storybook Dev

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,11 +136,12 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options = 
       const componentTag = parseTagConfig(code)
       const compilerFilePath = path.resolve(distCustomElementsOptions.dir, `${componentTag}.js`)
 
+      const raw = await buildQueue.getLatestBuild(id, compilerFilePath)
+
       const exists = await compiler.sys.access(compilerFilePath)
       if (!exists)
         throw new Error('Could not find the output file')
 
-      const raw = await buildQueue.getLatestBuild(id, compilerFilePath)
       const transformedCode = await transformCompiledCode(
         raw,
         compilerFilePath,


### PR DESCRIPTION
## Problem:

When running a clean installation of the project without generating a build using stencil build, the following error is thrown:

```lua
[vite] (client) Pre-transform error: Could not find the output file
  Plugin: unplugin-stencil
  File: /Users/git/unplugin-stencil/playground/components/my-component/my-component.tsx

[vite] Internal server error: Could not find the output file
  Plugin: unplugin-stencil
```

This error occurs because there are no build files present. The following code explicitly throws an error when the file is not found:

```typescript
const exists = await compiler.sys.access(compilerFilePath)
      if (!exists)
        throw new Error('Could not find the output file')
```

## Fix
Updated the logic to allow storybook dev to run even if the Stencil build output is missing. This ensures that developers can start Storybook in a clean state without requiring a prior stencil build.

