### PR TITLE
fix: support win32 paths when transforming compiled code

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,13 +173,20 @@ export function transformCompiledCode(code: string, outputPath: string) {
      * }
      * ```
      *
-     * the new import will be:
+     * if on a POSIX system, the new import will be:
      *
      * ```js
      * import { f as format } from '/path/to/project/dist/components/utils.js';
      * ```
+     *
+     * or, if on a WIN32 system:
+     *
+     * ```js
+     * import { f as format } from 'C:/path/to/project/dist/components/utils.js';
+     * ```
      */
-    const newImport = imp.code.replace(imp.specifier, path.posix.resolve(outputDir, imp.specifier))
+    const localizedOutputPath = path.resolve(outputDir, imp.specifier)
+    const newImport = imp.code.replace(imp.specifier, localizedOutputPath.split(path.sep).join(path.posix.sep))
     code = code.replace(imp.code, newImport)
   }
 
@@ -249,7 +256,8 @@ export function transformCompiledCode(code: string, outputPath: string) {
      */
     const namedImport = Object.entries(componentImport?.namedImports || {})[0]
     if (namedImport && componentImport) {
-      code += `\nexport { ${namedImport.join(' as ')} } from '${path.posix.resolve(outputDir, componentImport.specifier)}';\n`
+      const localizedOutputPath = path.resolve(outputDir, componentImport.specifier)
+      code += `\nexport { ${namedImport.join(' as ')} } from '${localizedOutputPath.split(path.sep).join(path.posix.sep)}';\n`
     }
   }
 


### PR DESCRIPTION
I encountered a critical bug on Windows where import paths are parsed very wrong when being processed.

This means anyone using stencil + storybook on Windows will get an import error when loading the component in Storybook

Essentially, `transformCompiledCode()` would replace "./index.js" in, for example, `dist/components/my-component.js` with:

`/Users/veryloud/Projects/my-project/C:UsersveryloudProjectsmy-projectdistcomponents/index.js`

This fix makes sure the path method that is correct for the user's system is used.