### PR TITLE
feat: rename to @stencil-community/unplugin-stencil

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  # NPM_CONFIG_PROVENANCE: true
+  NPM_CONFIG_PROVENANCE: true
 
 jobs:
   release:
@@ -28,12 +28,12 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-      - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -44,8 +44,8 @@ jobs:
           npm whoami
       - name: Git Setup
         run: |
-          git config --global user.email 'git@bromann.dev'
-          git config --global user.name 'Christian Bromann'
+          git config --global user.email 'action@github.com'
+          git config --global user.name 'GitHub Actions'
       - name: Install Dependencies
         run: pnpm install
       - name: Build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stencil Unplugin
 
-[![NPM version](https://img.shields.io/npm/v/unplugin-stencil?color=a1b858&label=)](https://www.npmjs.com/package/unplugin-stencil)
+[![NPM version](https://img.shields.io/npm/v/@stencil-community/unplugin-stencil?color=a1b858&label=)](https://www.npmjs.com/package/@stencil-community/unplugin-stencil)
 
 An unplugin that wraps the [Stencil](https://stenciljs.com/) compiler to be used within Astro, Esbuild, Nuxt, Rollup, rspack, Vite and Webpack etc. environments.
 
@@ -9,7 +9,7 @@ An unplugin that wraps the [Stencil](https://stenciljs.com/) compiler to be used
 To install this unplugin, run:
 
 ```bash
-npm i unplugin-stencil
+npm i @stencil-community/unplugin-stencil
 ```
 
 <details>
@@ -17,7 +17,7 @@ npm i unplugin-stencil
 
 ```ts
 // vite.config.ts
-import stencil from 'unplugin-stencil/vite'
+import stencil from '@stencil-community/unplugin-stencil/vite'
 
 export default defineConfig({
   plugins: [
@@ -33,7 +33,7 @@ export default defineConfig({
 
 ```ts
 // rollup.config.js
-import Starter from 'unplugin-stencil/rollup'
+import Starter from '@stencil-community/unplugin-stencil/rollup'
 
 export default {
   plugins: [
@@ -52,7 +52,7 @@ export default {
 module.exports = {
   /* ... */
   plugins: [
-    require('unplugin-stencil/webpack')({ /* options */ })
+    require('@stencil-community/unplugin-stencil/webpack')({ /* options */ })
   ]
 }
 ```
@@ -66,7 +66,7 @@ module.exports = {
 // nuxt.config.js
 export default defineNuxtConfig({
   modules: [
-    ['unplugin-stencil/nuxt', { /* options */ }],
+    ['@stencil-community/unplugin-stencil/nuxt', { /* options */ }],
   ],
 })
 ```
@@ -83,7 +83,7 @@ export default defineNuxtConfig({
 module.exports = {
   configureWebpack: {
     plugins: [
-      require('unplugin-stencil/webpack')({ /* options */ }),
+      require('@stencil-community/unplugin-stencil/webpack')({ /* options */ }),
     ],
   },
 }
@@ -96,8 +96,8 @@ module.exports = {
 
 ```ts
 // esbuild.config.js
+import Starter from '@stencil-community/unplugin-stencil/esbuild'
 import { build } from 'esbuild'
-import Starter from 'unplugin-stencil/esbuild'
 
 build({
   plugins: [Starter()],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "unplugin-stencil",
+  "name": "@stencil-community/unplugin-stencil",
   "type": "module",
   "version": "0.4.1",
   "packageManager": "pnpm@10.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (
     = process.env.NODE_ENV === 'test' || process.env.VITEST === 'true'
 
   return {
-    name: 'unplugin-stencil',
+    name: '@stencil-community/unplugin-stencil',
     enforce: 'pre',
     /**
      * This hook is called when the build starts. It is a good place to initialize


### PR DESCRIPTION
Follow-up to #13.

## Summary

- Rename package from `unplugin-stencil` to `@stencil-community/unplugin-stencil` in `package.json` and the unplugin name string.
- Update README badge, install command, and all import examples.
- Bump `actions/checkout@v2` → `@v4` and `pnpm/action-setup@v3` → `@v4` in `release.yml` (fixes the Node 20 deprecation warning from the last publish attempt).
- Replace hardcoded `git@bromann.dev` git identity with `action@github.com` / `GitHub Actions`.
- Uncomment `NPM_CONFIG_PROVENANCE: true` for npm provenance attestation.

## Test plan

- [x] `pnpm exec vitest run test/`
- [x] `pnpm build`