### PR TITLE
fix: seed component style dependency map at buildStart

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,12 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (
       compiler = await createCompiler(validated.config)
       buildQueue = new BuildQueue(compiler)
 
+      // Seed the style-dependency map before any `transform` short-circuits.
+      // `getLatestBuild` skips building when `dist/` is newer than source (the
+      // common pre-built dev-server case), so `buildFinished` may never fire on
+      // a cold start. Scanning here makes the API correct from the first edit.
+      await rebuildStyleMap(compiler.sys, stencilConfig)
+
       onBuildFinished = () => {
         if (compiler && stencilConfig)
           void rebuildStyleMap(compiler.sys, stencilConfig)
@@ -229,7 +235,9 @@ export const unplugin = /* #__PURE__ */ createUnplugin(unpluginFactory)
 export { stencilBuildEvents } from './build-events.js'
 export {
   type ComponentStyleDependencies,
+  extractStylePathsFromSource,
   getComponentStyleDependencies,
+  rebuildStyleMap,
 } from './style-dependencies.js'
 
 export default unplugin

--- a/test/style-dependencies.test.ts
+++ b/test/style-dependencies.test.ts
@@ -139,4 +139,36 @@ export class Cmp {}
       new Set([path.resolve(cmpPath)]),
     )
   })
+
+  it('seeds globalStyle and an empty graph for a component-less scan', async () => {
+    clearStyleDependencies()
+
+    const rootDir = path.resolve('/project')
+    const srcDir = path.join(rootDir, 'src')
+
+    const sys = {
+      readDir: async () => [],
+      stat: async () => ({
+        isDirectory: false,
+        isFile: false,
+        isSymbolicLink: false,
+        size: 0,
+        mtimeMs: 0,
+        ctimeMs: 0,
+        atimeMs: 0,
+      }),
+      readFile: async () => '',
+    } as unknown as CompilerSystem
+
+    await rebuildStyleMap(sys, {
+      rootDir,
+      srcDir,
+      globalStyle: 'src/global.css',
+    })
+
+    const deps = getComponentStyleDependencies()
+    expect(deps.byComponent.size).toBe(0)
+    expect(deps.byStyle.size).toBe(0)
+    expect(deps.globalStyle).toBe(path.resolve(rootDir, 'src/global.css'))
+  })
 })


### PR DESCRIPTION
Follow-up to #13 / #15 (v0.5.0), addressing two gaps that surfaced while wiring `@stencil/storybook-plugin` onto the new API. Both are additive and non-breaking.

## Gap 1 — style map is empty on a cold dev server (the important one)

`rebuildStyleMap` was only wired to `BuildQueue`'s `buildFinished`. But the first `transform` goes through `getLatestBuild`, which **short-circuits without building** when `dist/` is newer than source — the common case, since projects are pre-built before `storybook dev`. No build runs, `buildFinished` never fires, and `getComponentStyleDependencies()` returns empty maps. The first stylesheet edit on a fresh dev server then has nothing to route to; it only starts working after some unrelated edit forces a real rebuild.

**Fix:** seed the map once at `buildStart`, right after the compiler is created:

```ts
compiler = await createCompiler(validated.config)
buildQueue = new BuildQueue(compiler)
await rebuildStyleMap(compiler.sys, stencilConfig) // seed before any transform short-circuits
```

`rebuildStyleMap` already does a standalone `srcDir` scan via `sys.readDir`/`readFile`, so it doesn't depend on a completed build — making the API correct from the very first watcher event for eager projects, lazy projects, and `globalStyle` alike.

## Gap 2 — helpers not re-exported from the package root

`dist/index.d.ts` only re-exported `getComponentStyleDependencies` and `stencilBuildEvents`. Consumers that need to seed their own map had to reach in via the brittle deep path `@stencil-community/unplugin-stencil/dist/style-dependencies.cjs`. Now `extractStylePathsFromSource` and `rebuildStyleMap` are re-exported from the root entry. (With Gap 1 fixed, consumers shouldn't need to seed at all — but the public exports remove the fragile deep import either way.)

## Test plan

- [x] `pnpm exec vitest run test/` (20 passing; added a cold-start case asserting `rebuildStyleMap` seeds `globalStyle` with an empty component graph)
- [x] `pnpm lint`
- [x] `pnpm build` — verified `dist/index.d.ts` now re-exports `extractStylePathsFromSource` and `rebuildStyleMap`