### PR TITLE
fix(style-dependencies): use absolute paths from sys.readDir in collectTsxFiles

### DIFF
--- a/src/style-dependencies.ts
+++ b/src/style-dependencies.ts
@@ -128,7 +128,10 @@ async function collectTsxFiles(
   }
 
   for (const entry of entries) {
-    const fullPath = path.join(dir, entry)
+    // `sys.readDir` returns full normalized paths, not basenames, so use the
+    // entry directly. Re-joining with `dir` would double the path and break
+    // every subsequent `stat`, leaving the dependency map empty.
+    const fullPath = entry
     let stat: { isDirectory: boolean, isFile: boolean } | undefined
     try {
       stat = await sys.stat(fullPath)

--- a/test/style-dependencies.test.ts
+++ b/test/style-dependencies.test.ts
@@ -112,14 +112,69 @@ export class Cmp {}
     ])
 
     const sys = {
+      // `sys.readDir` returns full normalized paths, not basenames.
       readDir: async (dir: string) => {
         if (dir === srcDir)
-          return ['cmp.tsx']
+          return [cmpPath]
         return []
       },
       stat: async (p: string) => ({
         isDirectory: p === srcDir,
         isFile: p === cmpPath,
+        isSymbolicLink: false,
+        size: 0,
+        mtimeMs: 0,
+        ctimeMs: 0,
+        atimeMs: 0,
+      }),
+      readFile: async (p: string) => files.get(p) ?? '',
+    } as unknown as CompilerSystem
+
+    await rebuildStyleMap(sys, { rootDir, srcDir })
+
+    const deps = getComponentStyleDependencies()
+    expect(deps.byComponent.get(path.resolve(cmpPath))).toEqual(
+      new Set([path.resolve(cssPath)]),
+    )
+    expect(deps.byStyle.get(path.resolve(cssPath))).toEqual(
+      new Set([path.resolve(cmpPath)]),
+    )
+  })
+
+  it('recurses into nested dirs using absolute paths from sys.readDir', async () => {
+    clearStyleDependencies()
+
+    const rootDir = path.resolve('/project')
+    const srcDir = path.join(rootDir, 'src')
+    const componentsDir = path.join(srcDir, 'components')
+    const cmpDir = path.join(componentsDir, 'my-cmp')
+    const cmpPath = path.join(cmpDir, 'my-cmp.tsx')
+    const cssPath = path.join(cmpDir, 'my-cmp.css')
+
+    const files = new Map<string, string>([
+      [
+        cmpPath,
+        `
+import { Component } from '@stencil/core'
+@Component({ tag: 'my-cmp', styleUrl: 'my-cmp.css' })
+export class MyCmp {}
+`,
+      ],
+    ])
+
+    // sys.readDir returns full normalized paths at every level.
+    const dirEntries = new Map<string, string[]>([
+      [srcDir, [componentsDir]],
+      [componentsDir, [cmpDir]],
+      [cmpDir, [cmpPath, cssPath]],
+    ])
+    const directories = new Set([srcDir, componentsDir, cmpDir])
+
+    const sys = {
+      readDir: async (dir: string) => dirEntries.get(dir) ?? [],
+      stat: async (p: string) => ({
+        isDirectory: directories.has(p),
+        isFile: !directories.has(p),
         isSymbolicLink: false,
         size: 0,
         mtimeMs: 0,


### PR DESCRIPTION
Follow-up to #16 (v0.5.1). The seeding and re-export work shipped correctly, but `getComponentStyleDependencies()` still returned **empty** maps (`byComponent=0`, `byStyle=0`) on every project — traced to a path bug in `collectTsxFiles`, independent of the seeding work.

## The bug

`collectTsxFiles` built each child path with `path.join(dir, entry)`, but Stencil's `sys.readDir()` **already returns full normalized paths**, not basenames (confirmed in `stencil-public-compiler.d.ts`: _"All return paths are full normalized paths, not just the basenames."_). So `path.join` doubled the path and every `sys.stat` failed with `ENOENT`, leaving the file list empty — the map was *always* empty for every consumer.

```js
const entries = await sys.readDir('/abs/project/src')
// entries[0] === '/abs/project/src/components'        <-- already absolute
path.join('/abs/project/src', entries[0])
// === '/abs/project/src/abs/project/src/components'    <-- doubled, ENOENT
```

## The fix

Use the entry directly, since `sys.readDir` already returns absolute paths:

```ts
for (const entry of entries) {
  const fullPath = entry // sys.readDir() returns full normalized paths
  ...
}
```

## Tests

The existing `rebuildStyleMap` test mock returned **basenames** from `readDir` (`['cmp.tsx']`), contradicting the real contract — which is why it passed against the buggy code. Corrected the mocks to return absolute paths and added a nested-directory case (`src/components/my-cmp/my-cmp.tsx`) that exercises the recursion.

Verified both updated tests **fail** against the pre-fix implementation and **pass** with the fix.

## Test plan

- [x] `pnpm exec vitest run test/` (21 passing)
- [x] `pnpm lint`
- [x] `pnpm build` — confirmed compiled `collectTsxFiles` uses `const fullPath = entry`
- [x] Reporter verified against the storybook plugin e2e suites (eager + lazy: HMR incl. stylesheet + render all green) with the consumer-side seed removed